### PR TITLE
Use proper formula to calculate baud rate, use doublespeed mode if needed

### DIFF
--- a/src/hw_uart.c
+++ b/src/hw_uart.c
@@ -6,15 +6,24 @@
 #include "console.h"
 #include "watchdog.h"
 
-#define BAUD 9600
+// When doing calculations per page 174 od atmega168 datasheet,
+// make sure we use real numbers and round, not truncate
+#define UBRR_VAL ((1.0 * F_CPU / (16.0 * BAUD)) + 0.5 - 1)
+#define UBRR_DOUBLESPEED_VAL ((1.0 * F_CPU / (8.0 * BAUD)) + 0.5 - 1)
 
 void hw_uart_init(void)
 {
 #if __AVR_ATmega168__
-    UBRR0 = (F_CPU / (16UL * BAUD)) - 1;
+#if BAUD > 57600
+    // Setup lower divider to get higher precision for high baud rate.
+    UCSR0A |= _BV(U2X0);
+    UBRR0 = UBRR_DOUBLESPEED_VAL;
+#else
+    UBRR0 = UBRR_VAL;
+#endif
     UCSR0B = _BV(TXEN0) | _BV(RXEN0);
 #elif __AVR_AT90USB162__
-    UBRR1 = (F_CPU / (16UL * BAUD)) - 1;
+    UBRR1 = UBRR_VAL;
     UCSR1B = _BV(TXEN1) | _BV(RXEN1);
 #else
 #error Unsupported device, FIXME

--- a/src/hw_uart.h
+++ b/src/hw_uart.h
@@ -1,6 +1,10 @@
 #ifndef HW_UART_H
 #define HW_UART_H 1
 
+#ifndef BAUD
+#define BAUD 9600
+#endif
+
 void hw_uart_init(void);
 void hw_uart_putc(char c);
 void hw_uart_tick(void);


### PR DESCRIPTION
Formula as given on page 174 of atmega168 datasheet (doc2545) of course
assumes real numbers and proper rounding. Using integers and truncation
makes 57600 the last working speed for Arduino Duemilanove, while proper
formula allows to work with 230400 (can't get higher due to Linux ft232
driver limitation).

Also, on higher baud rates, switch to double-speed mode to improve match
between atmega baud rate and standard baud rate values (see page 198),
otherwise 230400 doesn't really work due to high error.

Finally, allow to override baud rate from command line/*.mk file.
